### PR TITLE
Fix UnboundLocalError on parentDir when connecting to Samba (Linux) shares

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1261,13 +1261,13 @@ class SMB3:
            # Is this file NOT on the root directory?
            if len(fileName.split('\\')) > 2:
                parentDir = ntpath.dirname(pathName)
-           if parentDir in self.GlobalFileTable:
-               raise Exception("Don't know what to do now! :-o")
-           else:
-               parentEntry = copy.deepcopy(FILE)
-               parentEntry['LeaseKey']   = uuid.generate()
-               parentEntry['LeaseState'] = SMB2_LEASE_NONE
-               self.GlobalFileTable[parentDir] = parentEntry
+               if parentDir in self.GlobalFileTable:
+                   raise Exception("Don't know what to do now! :-o")
+               else:
+                   parentEntry = copy.deepcopy(FILE)
+                   parentEntry['LeaseKey']   = uuid.generate()
+                   parentEntry['LeaseState'] = SMB2_LEASE_NONE
+                   self.GlobalFileTable[parentDir] = parentEntry
 
         packet = self.SMB_PACKET()
         packet['Command'] = SMB2_CREATE


### PR DESCRIPTION
## Summary

When using any impacket-based tool (nxc, smbclient-ng, etc.) to connect to a
Samba/Linux SMB share, the connection fails with:

`[error] cannot access local variable 'parentDir' where it is not associated with a value`

This happens when the SMB server advertises dialect >= 3.0 with directory
leasing support, and the client accesses a file at the root of the share.

## Root cause

In `impacket/smb3.py`, the `SMB2_CREATE` handler has an indentation bug in the
directory leasing logic (around line 1267-1277):

```python
if len(fileName.split('\\')) > 2:
    parentDir = ntpath.dirname(pathName)
if parentDir in self.GlobalFileTable:   # <-- outside the guard!
```

`parentDir` is only assigned when the path has more than 2 components (i.e. not
at share root), but the code referencing it sits outside that `if` block. For
root-level paths (common on Samba shares) `parentDir` is never bound, causing
an `UnboundLocalError`.

## Fix

Move the `if parentDir in self.GlobalFileTable` / `else` block inside the
`if len(...) > 2:` guard, so that parent directory lease tracking is only
attempted when a parent directory actually exists:

```python
if len(fileName.split('\\')) > 2:
    parentDir = ntpath.dirname(pathName)
    if parentDir in self.GlobalFileTable:
        raise Exception("Don't know what to do now! :-o")
    else:
        parentEntry = copy.deepcopy(FILE)
        parentEntry['LeaseKey']   = uuid.generate()
        parentEntry['LeaseState'] = SMB2_LEASE_NONE
        self.GlobalFileTable[parentDir] = parentEntry
```

This matches the original intent described by the inline comment
"Is this file NOT on the root directory?".

## Impact

Affects any impacket consumer connecting to Samba/Linux shares over SMB3 with
directory leasing enabled. Windows shares are less commonly affected because
paths tend to include subdirectories (e.g. `C$\Windows\...`).